### PR TITLE
Correct dependency URL for holochain-anchors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ hdk = "=0.0.44-alpha3"
 hdk_proc_macros = "=0.0.44-alpha3"
 holochain_wasm_utils = "=0.0.44-alpha3"
 holochain_json_derive = "^0.0"
-holochain_anchors = { git = "https://github.com/eyss/holochain_anchors" }
+holochain_anchors = { git = "https://github.com/eyss/holochain-anchors" }


### PR DESCRIPTION
The URL had an underscore whereas the actual repo has a hyphen. I can't compile this zome without this fix.

Alternatively, eyss/holochain-anchors could be renamed to holochain_anchors so these fixes don't be made.